### PR TITLE
[Web]:[#33]: fix app root blocks height calculation

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1,9 +1,18 @@
+@use "./config/globalstyles/mixins";
+
+#root, html, body {
+  height: 100%;
+}
+
 .App {
   text-align: center;
+  height: 100%;
 }
 
 .app-content {
-  min-height: calc(100vh - 134px);
+  height: calc(100% - 134px);
+  @include mixins.display-flex($direction: column, $justify-content: flex-start);
+  overflow: scroll;
 }
 
 .App-logo {


### PR DESCRIPTION
# Pull Request

## Description

Fix app height calculation for root elements

## Screenshots

Before:
<img width="1680" alt="image" src="https://github.com/KhilchenkoYurii/InterActiMate/assets/38540993/f8220caf-e458-4c6f-9ab0-4853b9773c81">


After:
<img width="1680" alt="image" src="https://github.com/KhilchenkoYurii/InterActiMate/assets/38540993/dd31c79b-37c1-4ffd-9575-d1af17759349">


## Type of change

Please use an 'x' to check the box and delete options that are not relevant.

- [x] Bugfix
